### PR TITLE
fix(frontend-build): pass env variables from docker-compose in build process

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,11 @@ services:
     container_name: chatroomfrontend
     image: chatroomfrontend
     restart: unless-stopped
-    build: ./frontend
+    build: 
+      context: ./frontend
+      args:
+        - REACT_APP_BASE_URL=http://localhost:3000/
+        - REACT_APP_BASE_WS=ws://localhost:3001
     ports:
       - "80:80"
     links:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,8 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
+ARG REACT_APP_BASE_URL
+ARG REACT_APP_BASE_WS
 RUN npm run build
 
 FROM node:16-alpine

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -2,10 +2,12 @@ version: '3.8'
 
 services:
   chat-room-frontend:
-    build: .
+    build: 
+      context: .
+      args:
+        - REACT_APP_BASE_URL=http://localhost:3000/
+        - REACT_APP_BASE_WS=ws://localhost:3001
     ports:
       - "80:80"
     environment:
-      - REACT_APP_BASE_URL=http://localhost:3000/
-      - REACT_APP_BASE_WS=ws://localhost:3001
       - PORT=80


### PR DESCRIPTION
Based on [Adding Custom Environment Variables](https://create-react-app.dev/docs/adding-custom-environment-variables), environment variables for app created by `create-react-app` are embedded during **build time**.

Thus, we would need to pass those variables as arguments via `docker-compose` during build process (in `Dockerfile`). This PR addresses that issue. 